### PR TITLE
tcp.go becomes reusable

### DIFF
--- a/latency.go
+++ b/latency.go
@@ -186,7 +186,7 @@ func sendSyn(laddr, raddr string, port uint16) time.Time {
 	}
 
 	data := packet.Marshal()
-	packet.Checksum = csum(data, to4byte(laddr), to4byte(raddr))
+	packet.Checksum = Csum(data, to4byte(laddr), to4byte(raddr))
 
 	data = packet.Marshal()
 

--- a/tcp.go
+++ b/tcp.go
@@ -117,7 +117,7 @@ func (tcp *TCPHeader) Marshal() []byte {
 }
 
 // TCP Checksum
-func csum(data []byte, srcip, dstip [4]byte) uint16 {
+func Csum(data []byte, srcip, dstip [4]byte) uint16 {
 
 	pseudoHeader := []byte{
 		srcip[0], srcip[1], srcip[2], srcip[3],


### PR DESCRIPTION
Hello, @grahamking 
First of all, thank you for this package. It's very helped me.

I want to use tcp header written by you at tcp.go, but csum function was private.

This PR making it public.
Thank you.
